### PR TITLE
add message sweeper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e579a7752471abc2a8268df8b20005e3eadd975f585398f17efcfd8d4927371"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcd8291a340dd8ac70e18878bc4501dd7b4ff970cfa21c207d36ece51ea88fd"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,6 +139,8 @@ version = "0.1.1"
 dependencies = [
  "async-stream",
  "chrono",
+ "clap",
+ "duration-string",
  "futures",
  "serenity",
  "tokio",
@@ -159,6 +210,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b802d85aaf3a1cdb02b224ba472ebdea62014fccfcb269b95a4d76443b5ee5a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14a1a858f532119338887a4b8e1af9c60de8249cd7bafd68036a489e261e37b6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +260,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "command_attr"
@@ -282,12 +381,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "duration-string"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fcc1d9ae294a15ed05aeae8e11ee5f2b3fe971c077d45a42fb20825fba6ee13"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -451,6 +577,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +590,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "http"
@@ -575,10 +713,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "itoa"
@@ -621,6 +782,12 @@ checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
 name = "lock_api"
@@ -681,7 +848,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -719,7 +886,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -764,7 +931,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -903,6 +1070,20 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1100,6 +1281,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,7 +1415,7 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "tracing",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1432,6 +1619,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "uwl"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1626,6 +1819,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +88,9 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 name = "billyjoule"
 version = "0.1.1"
 dependencies = [
+ "async-stream",
+ "chrono",
+ "futures",
  "serenity",
  "tokio",
  "tracing",
@@ -124,9 +149,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
+ "time 0.1.45",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -295,6 +323,7 @@ checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -316,6 +345,17 @@ name = "futures-core"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -382,7 +422,7 @@ checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -640,7 +680,7 @@ checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -994,7 +1034,7 @@ dependencies = [
  "serde-value",
  "serde_json",
  "static_assertions",
- "time",
+ "time 0.3.20",
  "tokio",
  "tracing",
  "typemap_rev",
@@ -1118,6 +1158,17 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -1407,6 +1458,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "clap",
  "duration-string",
  "futures",
+ "human-duration",
  "serenity",
  "tokio",
  "tracing",
@@ -630,6 +631,12 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "human-duration"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37a429277d8afba0e1a2cf784b43f938dff72ce33e6aba477c3021997171c87b"
 
 [[package]]
 name = "hyper"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,15 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,17 +45,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,10 +66,10 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 name = "billyjoule"
 version = "0.1.1"
 dependencies = [
- "log",
- "pretty_env_logger",
  "serenity",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -283,19 +263,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "flate2"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,15 +412,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
@@ -494,15 +452,6 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
-
-[[package]]
-name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
 
 [[package]]
 name = "hyper"
@@ -607,6 +556,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "levenshtein"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,6 +645,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,7 +679,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
 ]
 
@@ -732,6 +697,12 @@ checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -781,16 +752,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "pretty_env_logger"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
-dependencies = [
- "env_logger",
- "log",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,12 +759,6 @@ checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -852,23 +807,6 @@ checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
-
-[[package]]
-name = "regex"
-version = "1.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "reqwest"
@@ -1076,6 +1014,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,6 +1108,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.15",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -1296,6 +1253,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1402,6 +1385,12 @@ name = "uwl"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4bf03e0ca70d626ecc4ba6b0763b934b6f2976e8c744088bb3c1d646fbb1ad0"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ chrono = "0.4.24"
 clap = { version = "4.2.2", features = ["derive"] }
 duration-string = "0.3.0"
 futures = "0.3.28"
+human-duration = "0.1.0"
 serenity = "0.11.5"
 tokio = { version = "1.27.0", features = ["tracing", "macros", "rt-multi-thread"] }
 tracing = "0.1.37"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pretty_env_logger = "0.4.0"
-log = "0.4.17"
 serenity = "0.11.5"
 tokio = { version = "1.27.0", features = ["tracing", "macros", "rt-multi-thread"] }
+tracing = "0.1.37"
+tracing-subscriber = "0.3.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2021"
 [dependencies]
 async-stream = "0.3.5"
 chrono = "0.4.24"
+clap = { version = "4.2.2", features = ["derive"] }
+duration-string = "0.3.0"
 futures = "0.3.28"
 serenity = "0.11.5"
 tokio = { version = "1.27.0", features = ["tracing", "macros", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-stream = "0.3.5"
+chrono = "0.4.24"
+futures = "0.3.28"
 serenity = "0.11.5"
 tokio = { version = "1.27.0", features = ["tracing", "macros", "rt-multi-thread"] }
 tracing = "0.1.37"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM docker.io/ubuntu:22.04
 ARG TARGETARCH
+ARG GUILD_ID
+ARG CHANNEL_ID
 
 RUN mkdir -p /opt/billyjoule
 WORKDIR /opt/billyjoule
 COPY ./tools/target_arch.sh /opt/billyjoule
 RUN --mount=type=bind,target=/context \
  cp /context/target/$(/opt/tolerable/target_arch.sh)/release/billyjoule /opt/billyjoule/billyjoule
-CMD ["/opt/billyjoule/billyjoule"]
+CMD ["/opt/billyjoule/billyjoule", "--guild-id", "$GUILD_ID", "--channel-id", "$CHANNEL_ID"]
 EXPOSE 9090

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use tracing::error;
 use models::handler::Handler;
 use models::handler::GENERAL_GROUP;
 
-use crate::models::sweeper::{run_sweeper, Sweeper};
+use crate::models::sweeper::{run_sweeper, StatsReceiver, Sweeper};
 
 mod models;
 
@@ -55,7 +55,7 @@ async fn main() {
     );
 
     // Init handler.
-    let (handler, ready) = Handler::new(stats);
+    let (handler, ready) = Handler::new(args.guild_id.into());
 
     // Start sweeper.
     tokio::spawn(run_sweeper(sweeper, ready));
@@ -71,6 +71,10 @@ async fn main() {
         .event_handler(handler)
         .await
         .expect("Err creating client");
+
+    let mut data = client.data.write().await;
+    data.insert::<StatsReceiver>(stats);
+    drop(data);
 
     if let Err(why) = client.start().await {
         error!("Client error: {:?}", why);

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,10 +23,19 @@ struct Args {
     #[arg(long)]
     channel_id: u64,
 
-    #[arg(long, default_value = "1d", value_parser = parse_duration)]
+    #[arg(
+        long,
+        help = "The age of a message before it's deleted", 
+        default_value = "1d", 
+        value_parser = parse_duration,
+    )]
     max_message_age: Duration,
 
-    #[arg(long, default_value = "false")]
+    #[arg(
+        long,
+        help = "When set, does not actually delete messages",
+        default_value = "false"
+    )]
     dry_run: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,41 @@
-mod models;
+use std::env;
+
+use chrono::Duration;
+use clap::Parser;
+use duration_string::DurationString;
+use serenity::framework::standard::StandardFramework;
+use serenity::http::Http;
+use serenity::prelude::*;
+use tracing::error;
 
 use models::handler::Handler;
 use models::handler::GENERAL_GROUP;
-use serenity::framework::standard::StandardFramework;
-use serenity::prelude::*;
-use std::env;
-use tracing::error;
 
-#[tokio::main]
+use crate::models::sweeper::{run_sweeper, Sweeper};
+
+mod models;
+
+#[derive(Debug, Parser)]
+struct Args {
+    #[arg(long)]
+    guild_id: u64,
+
+    #[arg(long)]
+    channel_id: u64,
+
+    #[arg(long, default_value = "1d", value_parser = parse_duration)]
+    max_message_age: Duration,
+
+    #[arg(long, default_value = "false")]
+    dry_run: bool,
+}
+
+fn parse_duration(arg: &str) -> Result<Duration, String> {
+    arg.parse::<DurationString>()
+        .and_then(|ds| Duration::from_std(ds.into()).map_err(|err| err.to_string()))
+}
+
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     // setup logging
     tracing_subscriber::fmt::init();
@@ -16,18 +44,34 @@ async fn main() {
     let token =
         env::var("DISCORD_TOKEN").expect("DISCORD_TOKEN must be set in environment to execute");
 
-    let intents = GatewayIntents::GUILD_MESSAGES
-        | GatewayIntents::DIRECT_MESSAGES
-        | GatewayIntents::MESSAGE_CONTENT;
+    // Init sweeper.
+    let args = Args::parse();
+    let http = Http::new(&token);
+    let (sweeper, stats) = Sweeper::new(
+        http,
+        args.channel_id.into(),
+        args.max_message_age,
+        args.dry_run,
+    );
+
+    // Init handler.
+    let (handler, ready) = Handler::new(stats);
+
+    // Start sweeper.
+    tokio::spawn(run_sweeper(sweeper, ready));
+
+    let intents = GatewayIntents::GUILDS | GatewayIntents::GUILD_MESSAGES;
 
     let framework = StandardFramework::new()
         .configure(|c| c.prefix("."))
         .group(&GENERAL_GROUP);
+
     let mut client = Client::builder(&token, intents)
         .framework(framework)
-        .event_handler(Handler)
+        .event_handler(handler)
         .await
         .expect("Err creating client");
+
     if let Err(why) = client.start().await {
         error!("Client error: {:?}", why);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,25 +1,20 @@
-#[macro_use]
-extern crate log;
-
 mod models;
 
-use std::env;
-use serenity::framework::standard::StandardFramework;
-use serenity::prelude::*;
 use models::handler::Handler;
 use models::handler::GENERAL_GROUP;
+use serenity::framework::standard::StandardFramework;
+use serenity::prelude::*;
+use std::env;
+use tracing::error;
 
 #[tokio::main]
 async fn main() {
-
     // setup logging
-    if let Err(e) = pretty_env_logger::try_init_timed() {
-        eprintln!("logging couldn't initialize: {e}");
-        panic!("can't continue when logger offline");
-    }
+    tracing_subscriber::fmt::init();
 
     // get token
-    let token = env::var("DISCORD_TOKEN").expect("DISCORD_TOKEN must be set in environment to execute");
+    let token =
+        env::var("DISCORD_TOKEN").expect("DISCORD_TOKEN must be set in environment to execute");
 
     let intents = GatewayIntents::GUILD_MESSAGES
         | GatewayIntents::DIRECT_MESSAGES
@@ -28,14 +23,12 @@ async fn main() {
     let framework = StandardFramework::new()
         .configure(|c| c.prefix("."))
         .group(&GENERAL_GROUP);
-    let mut client =
-        Client::builder(&token, intents)
-            .framework(framework)
-            .event_handler(Handler)
-            .await
-            .expect("Err creating client");
+    let mut client = Client::builder(&token, intents)
+        .framework(framework)
+        .event_handler(Handler)
+        .await
+        .expect("Err creating client");
     if let Err(why) = client.start().await {
-        println!("Client error: {:?}", why);
+        error!("Client error: {:?}", why);
     }
-
 }

--- a/src/models/handler.rs
+++ b/src/models/handler.rs
@@ -4,14 +4,34 @@ use serenity::framework::standard::CommandResult;
 use serenity::model::channel::Message;
 use serenity::model::gateway::Ready;
 use serenity::prelude::*;
+use tokio::sync::{mpsc, watch};
 use tracing::info;
 
+use crate::models::sweeper::Stats;
+
 // event handler
-pub struct Handler;
+pub struct Handler {
+    ready: mpsc::Sender<()>,
+    stats: watch::Receiver<Stats>,
+}
+
+impl Handler {
+    pub(crate) fn new(stats: watch::Receiver<Stats>) -> (Self, mpsc::Receiver<()>) {
+        // Using `mpsc` over `oneshot` so we can send a signal without a &mut self.
+        let (ready, rx) = mpsc::channel(1);
+        (Handler { ready, stats }, rx)
+    }
+}
+
 #[async_trait]
 impl EventHandler for Handler {
     async fn ready(&self, _: Context, ready: Ready) {
         info!("{} is connected!", ready.user.name);
+
+        self.ready
+            .send(())
+            .await
+            .expect("failed to send start signal");
     }
 }
 

--- a/src/models/handler.rs
+++ b/src/models/handler.rs
@@ -1,38 +1,111 @@
+use crate::models::sweeper::{Stats, StatsReceiver};
+use chrono::Utc;
+use human_duration::human_duration;
 use serenity::async_trait;
 use serenity::framework::standard::macros::{command, group};
 use serenity::framework::standard::CommandResult;
+use serenity::model::application::interaction::Interaction;
+use serenity::model::application::interaction::Interaction::ApplicationCommand;
 use serenity::model::channel::Message;
 use serenity::model::gateway::Ready;
+use serenity::model::id::GuildId;
+use serenity::model::prelude::interaction::InteractionResponseType;
 use serenity::prelude::*;
-use tokio::sync::{mpsc, watch};
-use tracing::info;
-
-use crate::models::sweeper::Stats;
+use tokio::sync::mpsc;
+use tracing::{debug, error, info};
 
 // event handler
 pub struct Handler {
+    guild_id: GuildId,
     ready: mpsc::Sender<()>,
-    stats: watch::Receiver<Stats>,
 }
 
 impl Handler {
-    pub(crate) fn new(stats: watch::Receiver<Stats>) -> (Self, mpsc::Receiver<()>) {
+    pub(crate) fn new(guild_id: GuildId) -> (Self, mpsc::Receiver<()>) {
         // Using `mpsc` over `oneshot` so we can send a signal without a &mut self.
         let (ready, rx) = mpsc::channel(1);
-        (Handler { ready, stats }, rx)
+        (Handler { guild_id, ready }, rx)
     }
 }
 
 #[async_trait]
 impl EventHandler for Handler {
-    async fn ready(&self, _: Context, ready: Ready) {
+    async fn ready(&self, ctx: Context, ready: Ready) {
         info!("{} is connected!", ready.user.name);
+
+        // Configure stats command.
+        self.guild_id
+            .set_application_commands(&ctx.http, |builder| {
+                builder.create_application_command(|command| {
+                    command.name("stats").description("Get sweeper stats")
+                })
+            })
+            .await
+            .expect("failed to create app commands");
+        info!("Created app commands");
 
         self.ready
             .send(())
             .await
             .expect("failed to send start signal");
     }
+
+    async fn interaction_create(&self, ctx: Context, interaction: Interaction) {
+        if let ApplicationCommand(command) = interaction {
+            if command.data.name != "stats" {
+                debug!(command = command.data.name, "Received unknown command.");
+                return;
+            }
+
+            let stats = match get_stats(&ctx).await {
+                None => {
+                    error!("Stats don't exist, but they should.");
+                    return;
+                }
+                Some(stats) => stats,
+            };
+
+            if let Err(error) = command
+                .create_interaction_response(&ctx.http, |resp| {
+                    resp.kind(InteractionResponseType::ChannelMessageWithSource)
+                        .interaction_response_data(|message| {
+                            let uptime = (Utc::now() - stats.started)
+                                .to_std()
+                                .expect("Duration should be in range");
+
+                            message
+                                .content(":wave: Hey there, here are some sweeper stats")
+                                .embed(|embed| {
+                                    embed
+                                        .field("Uptime", human_duration(&uptime), false)
+                                        .field("Runs", format!("Ran {} times", stats.runs), false)
+                                        .field(
+                                            "Last Run",
+                                            format!("Cleaned up {} messages.", stats.last_run),
+                                            false,
+                                        )
+                                        .field(
+                                            "All Runs",
+                                            format!("Cleaned up {} messages.", stats.all_runs),
+                                            false,
+                                        )
+                                })
+                        })
+                })
+                .await
+            {
+                error!(error = %error, "Failed to respond to status command.");
+            }
+        }
+    }
+}
+
+async fn get_stats(ctx: &Context) -> Option<Stats> {
+    ctx.data
+        .read()
+        .await
+        .get::<StatsReceiver>()
+        .map(|sr| sr.borrow().clone())
 }
 
 // command groups

--- a/src/models/handler.rs
+++ b/src/models/handler.rs
@@ -1,10 +1,10 @@
 use serenity::async_trait;
-use serenity::framework::standard::CommandResult;
 use serenity::framework::standard::macros::{command, group};
+use serenity::framework::standard::CommandResult;
 use serenity::model::channel::Message;
 use serenity::model::gateway::Ready;
 use serenity::prelude::*;
-
+use tracing::info;
 
 // event handler
 pub struct Handler;
@@ -15,14 +15,11 @@ impl EventHandler for Handler {
     }
 }
 
-
 // command groups
 
 #[group]
 #[commands(ping)]
 struct General;
-
-
 
 #[command]
 async fn ping(ctx: &Context, msg: &Message) -> CommandResult {

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,2 +1,2 @@
 pub(crate) mod handler;
-mod sweeper;
+pub(crate) mod sweeper;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,1 +1,2 @@
 pub(crate) mod handler;
+mod sweeper;

--- a/src/models/sweeper.rs
+++ b/src/models/sweeper.rs
@@ -1,5 +1,5 @@
 use async_stream::try_stream;
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Duration, Utc};
 use serenity::futures::{Stream, TryStreamExt};
 use serenity::http::Http;
 use serenity::model::channel::Message;
@@ -7,56 +7,126 @@ use serenity::model::id::{ChannelId, MessageId};
 use std::future;
 use std::ops::Deref;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
+use tokio::sync::{mpsc, watch};
+use tokio::time::Instant;
 use tracing::{debug, error, info};
 
-struct Sweeper {
+pub(crate) async fn run_sweeper(mut sweeper: Sweeper, mut ready: mpsc::Receiver<()>) {
+    ready.recv().await.expect("failed to receive ready signal");
+
+    info!("Bot ready, starting sweep loop.");
+    loop {
+        let start = Instant::now();
+        sweeper.sweep_messages().await;
+        info!(
+            task_millis = start.elapsed().as_millis(),
+            stats = ?sweeper.stats,
+            "Ran sweeper. Sleeping for 1 hour."
+        );
+
+        tokio::time::sleep(Duration::hours(1).to_std().expect("1 hour is in range")).await;
+    }
+}
+
+pub(crate) struct Sweeper {
     http: Arc<Http>,
     channel_id: ChannelId,
     max_message_age: Duration,
     dry_run: bool,
+
+    stats: Stats,
+    stats_tx: watch::Sender<Stats>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Stats {
+    started: DateTime<Utc>,
+    runs: u32,
+    last_run: u32,
+    all_runs: u32,
 }
 
 impl Sweeper {
     pub(crate) fn new(
-        http: Arc<Http>,
+        http: Http,
         channel_id: ChannelId,
         max_message_age: Duration,
         dry_run: bool,
-    ) -> Self {
-        Sweeper {
-            http,
-            channel_id,
-            max_message_age,
-            dry_run,
-        }
+    ) -> (Self, watch::Receiver<Stats>) {
+        let stats = Stats {
+            started: Utc::now(),
+            runs: 0,
+            last_run: 0,
+            all_runs: 0,
+        };
+
+        let (tx, rx) = watch::channel(stats.clone());
+
+        (
+            Sweeper {
+                http: Arc::new(http),
+                channel_id,
+                max_message_age,
+                dry_run,
+                stats,
+                stats_tx: tx,
+            },
+            rx,
+        )
     }
 
-    pub(crate) async fn sweep_messages(&self) -> serenity::Result<u32> {
+    async fn sweep_messages(&mut self) {
         let cutoff_time = Utc::now() - self.max_message_age;
 
+        let success_count = Arc::new(AtomicU32::new(0));
+
         info!(%cutoff_time, "Sweeping expired messages.");
-        self.message_stream()
+        let res = self
+            .message_stream()
             .try_take_while(|message| future::ready(Ok(message.timestamp.deref() < &cutoff_time)))
-            .and_then(|message| async move {
-                debug!(self.dry_run, %message.id,  "Found expired message.");
+            .try_for_each(|message| {
+                let message_id = message.id;
+                let channel_id = self.channel_id;
+                let http = self.http.clone();
+                let dry_run = self.dry_run;
+                let success_count = success_count.clone();
 
-                if self.dry_run {
-                    return Ok(0);
-                }
+                async move {
+                    debug!(dry_run, %message_id,  "Found expired message.");
 
-                if !self.dry_run {
-                    self.channel_id
-                        .delete_message(&self.http, message.id)
-                        .await
-                        .map(|_| 1)
-                } else {
-                    Ok(0)
+                    if dry_run {
+                        return Ok(());
+                    }
+
+                    if !dry_run {
+                        channel_id.delete_message(http, message_id).await.map(|_| {
+                            success_count.fetch_add(1, Ordering::SeqCst);
+                        })
+                    } else {
+                        Ok(())
+                    }
                 }
             })
-            .inspect_err(|error| error!(%error, "Failed to sweep messages."))
-            .try_fold(0, |acc, k| future::ready(Ok(acc + k)))
-            .await
+            .await;
+
+        let success_count = success_count.load(Ordering::SeqCst);
+        match res {
+            Ok(()) => {
+                info!(count = success_count, "Successfully swept messages.");
+            }
+            Err(error) => {
+                error!(%error, "Failed to sweep messages");
+            }
+        }
+
+        self.stats.runs += 1;
+        self.stats.last_run = success_count;
+        self.stats.all_runs += success_count;
+        self.stats_tx
+            .send(self.stats.clone())
+            .expect("failed to update stats");
     }
 
     fn message_stream(&self) -> Pin<Box<impl Stream<Item = serenity::Result<Message>> + '_>> {
@@ -78,7 +148,7 @@ impl Sweeper {
     async fn load_messages(&self, cursor: impl Into<MessageId>) -> serenity::Result<Vec<Message>> {
         let mut messages = self
             .channel_id
-            .messages(&self.http, |b| b.after(cursor.into()).limit(1))
+            .messages(&self.http, |b| b.after(cursor.into()).limit(25))
             .await?;
 
         messages.sort_by_key(|m| m.timestamp);

--- a/src/models/sweeper.rs
+++ b/src/models/sweeper.rs
@@ -1,0 +1,87 @@
+use async_stream::try_stream;
+use chrono::{Duration, Utc};
+use serenity::futures::{Stream, TryStreamExt};
+use serenity::http::Http;
+use serenity::model::channel::Message;
+use serenity::model::id::{ChannelId, MessageId};
+use std::future;
+use std::ops::Deref;
+use std::pin::Pin;
+use std::sync::Arc;
+use tracing::{debug, error, info};
+
+struct Sweeper {
+    http: Arc<Http>,
+    channel_id: ChannelId,
+    max_message_age: Duration,
+    dry_run: bool,
+}
+
+impl Sweeper {
+    pub(crate) fn new(
+        http: Arc<Http>,
+        channel_id: ChannelId,
+        max_message_age: Duration,
+        dry_run: bool,
+    ) -> Self {
+        Sweeper {
+            http,
+            channel_id,
+            max_message_age,
+            dry_run,
+        }
+    }
+
+    pub(crate) async fn sweep_messages(&self) -> serenity::Result<u32> {
+        let cutoff_time = Utc::now() - self.max_message_age;
+
+        info!(%cutoff_time, "Sweeping expired messages.");
+        self.message_stream()
+            .try_take_while(|message| future::ready(Ok(message.timestamp.deref() < &cutoff_time)))
+            .and_then(|message| async move {
+                debug!(self.dry_run, %message.id,  "Found expired message.");
+
+                if self.dry_run {
+                    return Ok(0);
+                }
+
+                if !self.dry_run {
+                    self.channel_id
+                        .delete_message(&self.http, message.id)
+                        .await
+                        .map(|_| 1)
+                } else {
+                    Ok(0)
+                }
+            })
+            .inspect_err(|error| error!(%error, "Failed to sweep messages."))
+            .try_fold(0, |acc, k| future::ready(Ok(acc + k)))
+            .await
+    }
+
+    fn message_stream(&self) -> Pin<Box<impl Stream<Item = serenity::Result<Message>> + '_>> {
+        Box::pin(try_stream! {
+            let mut cursor = MessageId(0);
+            while let messages = self.load_messages(cursor).await? {
+                if messages.is_empty() {
+                    break;
+                }
+
+                for message in messages.into_iter() {
+                    cursor = message.id;
+                    yield message;
+                }
+            }
+        })
+    }
+
+    async fn load_messages(&self, cursor: impl Into<MessageId>) -> serenity::Result<Vec<Message>> {
+        let mut messages = self
+            .channel_id
+            .messages(&self.http, |b| b.after(cursor.into()).limit(1))
+            .await?;
+
+        messages.sort_by_key(|m| m.timestamp);
+        Ok(messages)
+    }
+}


### PR DESCRIPTION
Adds a sweeper task that runs hourly.

Additional minor changes:
- Replaced `pretty_env_logger` with the `tracing` crate. Its logs are also pretty, and serenity + tokio both use it internally. This way all logs come from the same place.
- Added CLI arg parsing with `clap`.
- The sweeper maintains some basic stats, and the bot gets a `/stats` command that prints the stats:
<img width="411" alt="Screenshot 2023-04-16 at 2 46 20 PM" src="https://user-images.githubusercontent.com/80237201/232334878-efc7b5e2-417e-48fe-b3c2-a10fe6a3a2e6.png">