### PR TITLE
first pass at trying to skip a pinned message.

### DIFF
--- a/src/models/sweeper.rs
+++ b/src/models/sweeper.rs
@@ -108,6 +108,11 @@ impl Sweeper {
                         return Ok(());
                     }
 
+                    if message.pinned {
+                        debug!(%message_id, "message is pinned, skipping.");
+                        return Ok(());
+                    }
+
                     if !dry_run {
                         channel_id.delete_message(http, message_id).await.map(|_| {
                             success_count.fetch_add(1, Ordering::SeqCst);


### PR DESCRIPTION
implements #6 

Quick PR that I think is all that we need to skip pinned messages.  Not sure how to easily test it beyond deploy it and see if it works.  I thought about trying to mock serenity's message response for a unit test and then backed away slowly